### PR TITLE
refactor(mcp): 重构集合管理逻辑并引入PHPStan静态分析工具

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,8 @@
         "hyperf/framework": "^3.1"
     },
     "require-dev": {
-        "friendsofphp/php-cs-fixer": "^3.73"
+        "friendsofphp/php-cs-fixer": "^3.73",
+        "phpstan/phpstan": "^2.0"
     },
     "autoload": {
         "psr-4": {
@@ -31,6 +32,7 @@
         }
     },
     "scripts": {
-        "cs-fix": "php-cs-fixer fix $1"
+        "cs-fix": "php-cs-fixer fix $1",
+        "analyse": "@php vendor/bin/phpstan analyse --memory-limit 512M -c phpstan.neon"
     }
 }

--- a/phpstan.neon
+++ b/phpstan.neon
@@ -1,0 +1,22 @@
+includes:
+
+parameters:
+  level: 6
+  parallel:
+    jobSize: 20
+    maximumNumberOfProcesses: 32
+    minimumNumberOfJobsPerProcess: 2
+  reportUnmatchedIgnoredErrors: false
+  paths:
+    - app/
+    - config/
+    - storage/languages
+  scanFiles:
+  excludePaths:
+  ignoreErrors:
+    -
+      identifier: missingType.iterableValue
+    -
+      identifier: missingType.generics
+    -
+      '#invalid type Swow\\Psr7\\Server\\ServerConnection#'

--- a/src/McpHandler.php
+++ b/src/McpHandler.php
@@ -95,9 +95,9 @@ class McpHandler
                 $result = [
                     'protocolVersion' => '2024-11-05',
                     'capabilities' => new Capabilities(
-                        CollectionManager::getToolsCollection($serverName)->isNotEmpty(),
-                        CollectionManager::getResourcesCollection($serverName)->isNotEmpty(),
-                        CollectionManager::getPromptsCollection($serverName)->isNotEmpty(),
+                        TypeCollection::getTools($serverName)->isNotEmpty(),
+                        TypeCollection::getResources($serverName)->isNotEmpty(),
+                        TypeCollection::getPrompts($serverName)->isNotEmpty(),
                     ),
                     'serverInfo' => [
                         'name' => $serverName,
@@ -115,10 +115,10 @@ class McpHandler
                 $this->sendMessage(['content' => [['type' => 'text', 'text' => (string) $result]]]);
                 break;
             case 'tools/list':
-                $this->sendMessage(['tools' => CollectionManager::getToolsCollection($serverName)]);
+                $this->sendMessage(['tools' => TypeCollection::getTools($serverName)]);
                 break;
             case 'resources/list':
-                $this->sendMessage(['resources' => CollectionManager::getResourcesCollection($serverName)]);
+                $this->sendMessage(['resources' => TypeCollection::getResources($serverName)]);
                 break;
             case 'resources/read':
                 /** @var Annotation\Resource $annotation */
@@ -129,7 +129,7 @@ class McpHandler
                 $this->sendMessage(['content' => [['uri' => $annotation->uri, 'mimeType' => $annotation->mimeType, 'text' => (string) $result]]]);
                 break;
             case 'prompts/list':
-                $this->sendMessage(['prompts' => CollectionManager::getPromptsCollection($serverName)]);
+                $this->sendMessage(['prompts' => TypeCollection::getPrompts($serverName)]);
                 break;
             case 'prompts/get':
                 /** @var Annotation\Prompt $annotation */

--- a/src/TypeCollection.php
+++ b/src/TypeCollection.php
@@ -18,7 +18,7 @@ use Hyperf\Mcp\Annotation\Prompt;
 use Hyperf\Mcp\Annotation\Resource;
 use Hyperf\Mcp\Annotation\Tool;
 
-class CollectionManager
+class TypeCollection
 {
     /**
      * @var Collection[][]
@@ -33,9 +33,11 @@ class CollectionManager
         if (isset(self::$collections[$serverName][$annotation])) {
             return self::$collections[$serverName][$annotation];
         }
+
         $classes = McpCollector::getMethodsByAnnotation($annotation, $serverName);
 
         self::$collections[$serverName][$annotation] = new Collection();
+
         foreach ($classes as $class) {
             /* @var array{class: string, method: string, annotation: AbstractMcpAnnotation} $class */
             self::$collections[$serverName][$annotation]->push($class['annotation']->toSchema());
@@ -43,17 +45,17 @@ class CollectionManager
         return self::$collections[$serverName][$annotation];
     }
 
-    public static function getToolsCollection(string $serverName): Collection
+    public static function getTools(string $serverName): Collection
     {
         return self::getCollection($serverName, Tool::class);
     }
 
-    public static function getResourcesCollection(string $serverName): Collection
+    public static function getResources(string $serverName): Collection
     {
         return self::getCollection($serverName, Resource::class);
     }
 
-    public static function getPromptsCollection(string $serverName): Collection
+    public static function getPrompts(string $serverName): Collection
     {
         return self::getCollection($serverName, Prompt::class);
     }


### PR DESCRIPTION
重构了集合管理逻辑，将 `CollectionManager` 替换为 `TypeCollection` 以简化代码结构并提高可维护性。同时，引入了 PHPStan 静态分析工具，并配置了相应的分析规则和脚本，以提升代码质量。