### PR TITLE
feat: 添加工具名称验证并优化响应处理

### DIFF
--- a/src/Annotation/Tool.php
+++ b/src/Annotation/Tool.php
@@ -37,6 +37,10 @@ class Tool extends McpAnnotation
 
     public function toSchema(): array
     {
+        if (!preg_match('/^[a-zA-Z0-9_]+$/', $this->name)) {
+            throw new \InvalidArgumentException('Tool name must be alphanumeric and underscores.');
+        }
+
         return [
             'name' => $this->name,
             'description' => $this->description,

--- a/src/Server/McpHandler.php
+++ b/src/Server/McpHandler.php
@@ -50,7 +50,7 @@ class McpHandler
                 $class = $this->container->get($class);
                 $result = $class->{$method}(...$request->params['arguments']);
 
-                $result = ['content' => [['type' => 'text', 'text' => (string) $result]]];
+                $result = ['content' => [['type' => 'text', 'text' => $result]]];
                 break;
             case 'tools/list':
                 $result = ['tools' => TypeCollection::getTools($serverName)];
@@ -64,7 +64,7 @@ class McpHandler
                 $class = $this->container->get($class);
                 $result = $class->{$method}();
 
-                $result = ['content' => [['uri' => $annotation->uri, 'mimeType' => $annotation->mimeType, 'text' => (string) $result]]];
+                $result = ['content' => [['uri' => $annotation->uri, 'mimeType' => $annotation->mimeType, 'text' => $result]]];
                 break;
             case 'prompts/list':
                 $result = ['prompts' => TypeCollection::getPrompts($serverName)];
@@ -75,7 +75,7 @@ class McpHandler
                 $class = $this->container->get($class);
                 $result = $class->{$method}(...$request->params['arguments']);
 
-                $result = ['messages' => [['role' => $annotation->role, 'content' => ['type' => 'text', 'text' => (string) $result]]]];
+                $result = ['messages' => [['role' => $annotation->role, 'content' => ['type' => 'text', 'text' => $result]]]];
                 break;
             case 'notifications/initialized':
             default:

--- a/src/Types/Message/Response.php
+++ b/src/Types/Message/Response.php
@@ -12,9 +12,23 @@ declare(strict_types=1);
 
 namespace Hyperf\Mcp\Types\Message;
 
-class Response implements MessageInterface
+use JsonSerializable;
+
+class Response implements MessageInterface, JsonSerializable
 {
     public function __construct(public int $id, public string $jsonrpc, public array $result)
     {
+    }
+
+    public function jsonSerialize(): mixed {
+        if (isset($this->result['text'])) {
+            $this->result['text'] = json_encode($this->result['text'], JSON_UNESCAPED_UNICODE);
+        }
+
+        return [
+            'id' => $this->id,
+            'jsonrpc' => $this->jsonrpc,
+            'result' => $this->result,
+        ];
     }
 }


### PR DESCRIPTION
- 在 `Tool.php` 中添加工具名称的正则验证，确保名称仅包含字母、数字和下划线
- 在 `Response.php` 中实现 `JsonSerializable` 接口，优化 `text` 字段的 JSON 编码
- 在 `McpHandler.php` 中移除不必要的字符串类型转换，简化响应处理逻辑